### PR TITLE
Fix: Transparent background for nav icons

### DIFF
--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -21,7 +21,7 @@ export function SiteHeader() {
               <div
                 className={buttonVariants({
                   size: 'sm',
-                  variant: 'ghost',
+                  variant: 'transparent',
                 })}
               >
                 <Icons.gitHub className="h-5 w-5" />
@@ -36,7 +36,7 @@ export function SiteHeader() {
               <div
                 className={buttonVariants({
                   size: 'sm',
-                  variant: 'ghost',
+                  variant: 'transparent',
                 })}
               >
                 <Icons.twitter className="h-5 w-5 fill-current" />
@@ -51,7 +51,7 @@ export function SiteHeader() {
               <div
                 className={buttonVariants({
                   size: 'sm',
-                  variant: 'ghost',
+                  variant: 'transparent',
                 })}
               >
                 <Icons.linkedIn className="h-5 w-5 fill-current" />
@@ -66,7 +66,7 @@ export function SiteHeader() {
               <div
                 className={buttonVariants({
                   size: 'sm',
-                  variant: 'ghost',
+                  variant: 'transparent',
                 })}
               >
                 <Icons.discord className="h-5 w-5 fill-current" />

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -10,7 +10,7 @@ export function ThemeToggle() {
 
   return (
     <Button
-      className="bg-transparent"
+      className="bg-transparent hover:bg-transparent focus:bg-transparent active:bg-transparent"
       variant="ghost"
       size="sm"
       onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -17,6 +17,8 @@ const buttonVariants = cva(
           'bg-secondary text-secondary-foreground hover:bg-secondary/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
         link: 'underline-offset-4 hover:underline text-primary',
+        transparent:
+          'bg-transparent hover:bg-transparent focus:bg-transparent active:bg-transparent',
       },
       size: {
         default: 'h-10 py-2 px-4',


### PR DESCRIPTION
This PR fixes the issue where the nav icons were getting a background color instead of being transparent. Now, the icons will blend seamlessly with the navigation bar. 